### PR TITLE
pieces: show source file [broken WIP]

### DIFF
--- a/apps/web/controllers/pieces/show.rb
+++ b/apps/web/controllers/pieces/show.rb
@@ -6,7 +6,7 @@ module Web::Controllers::Pieces
     expose :piece
 
     def call(params)
-      @piece = piece_repository.find params[:id]
+      @piece = piece_repository.find_with_source_file params[:id]
     end
   end
 end

--- a/apps/web/templates/pieces/show.html.slim
+++ b/apps/web/templates/pieces/show.html.slim
@@ -11,7 +11,7 @@ table
       td= piece.lyrics_cleaned
     tr
       th soubor
-      td
+      td= piece.source_file.full_path
     tr
       th id v rámci souboru
       td= piece.piece_id

--- a/lib/db.inadiutorium/repositories/piece_repository.rb
+++ b/lib/db.inadiutorium/repositories/piece_repository.rb
@@ -1,6 +1,17 @@
 class PieceRepository < Hanami::Repository
+  associations do
+    belongs_to :source_file
+  end
+
   def count
     pieces.count
+  end
+
+  def find_with_source_file(id)
+    aggregate(:source_file)
+      .where(id: id)
+      .one
+      .as(Piece)
   end
 
   def list(**query)

--- a/lib/db.inadiutorium/repositories/piece_repository.rb
+++ b/lib/db.inadiutorium/repositories/piece_repository.rb
@@ -3,6 +3,11 @@ class PieceRepository < Hanami::Repository
     belongs_to :source_file
   end
 
+  # hackety hack:
+  # call to a method of the underlying ROM implementation
+  # to make belongs_to association loading work
+  relations :source_files
+
   def count
     pieces.count
   end
@@ -10,8 +15,8 @@ class PieceRepository < Hanami::Repository
   def find_with_source_file(id)
     aggregate(:source_file)
       .where(id: id)
-      .one
       .as(Piece)
+      .one
   end
 
   def list(**query)


### PR DESCRIPTION
I can't find how to make loading a `belongs_to` association work. A call to `PieceRepository#find_with_source_file` results in a crash:

```
Boot Error

Something went wrong while loading /home/igneus/src/ruby/db.inadiutorium/config.ru
ROM::Registry::ElementNotFoundError: :source_files doesn't exist in ROM::RelationRegistry registry

/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-support-2.0.0/lib/rom/support/registry.rb:33:in `block in fetch'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-support-2.0.0/lib/rom/support/registry.rb:30:in `fetch'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-support-2.0.0/lib/rom/support/registry.rb:30:in `fetch'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-repository-0.3.1/lib/rom/repository/relation_proxy/combine.rb:219:in `combine_opts_for_assoc'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-repository-0.3.1/lib/rom/repository/relation_proxy/combine.rb:63:in `block in combine'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-repository-0.3.1/lib/rom/repository/relation_proxy/combine.rb:59:in `each'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-repository-0.3.1/lib/rom/repository/relation_proxy/combine.rb:59:in `combine'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rom-repository-0.3.1/lib/rom/repository/root.rb:76:in `aggregate'
/home/igneus/src/ruby/db.inadiutorium/lib/db.inadiutorium/repositories/piece_repository.rb:11:in `find_with_source_file'
/home/igneus/src/ruby/db.inadiutorium/apps/web/controllers/pieces/show.rb:9:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/callbacks.rb:195:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/callable.rb:71:in `block in call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/throwable.rb:143:in `block in _rescue'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/throwable.rb:141:in `catch'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/throwable.rb:141:in `_rescue'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-controller-0.8.1/lib/hanami/action/callable.rb:67:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-router-0.8.1/lib/hanami/routing/endpoint.rb:81:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:193:in `process_destination_path'
(eval):211:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:288:in `raw_call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-router-0.8.1/lib/hanami/routing/http_router.rb:155:in `raw_call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:142:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-router-0.8.1/lib/hanami/router.rb:1007:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/builder.rb:153:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-0.9.2/lib/hanami/middleware.rb:52:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-0.9.2/lib/hanami/application.rb:180:in `call'
/home/igneus/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/delegate.rb:83:in `method_missing'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:193:in `process_destination_path'
(eval):15:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:288:in `raw_call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-router-0.8.1/lib/hanami/routing/http_router.rb:155:in `raw_call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/http_router-0.11.2/lib/http_router.rb:142:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-router-0.8.1/lib/hanami/router.rb:1007:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/methodoverride.rb:22:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-0.9.2/lib/hanami/assets/static.rb:49:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/builder.rb:153:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-0.9.2/lib/hanami/app.rb:41:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/shotgun-0.9.2/lib/shotgun/loader.rb:86:in `proceed_as_child'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/shotgun-0.9.2/lib/shotgun/loader.rb:31:in `call!'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/shotgun-0.9.2/lib/shotgun/loader.rb:18:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/hanami-0.9.2/lib/hanami/assets/static.rb:49:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/lint.rb:49:in `_call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/lint.rb:37:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/showexceptions.rb:24:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/commonlogger.rb:33:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/content_length.rb:15:in `call'
/home/igneus/.rvm/gems/ruby-2.3.1/gems/rack-1.6.5/lib/rack/handler/webrick.rb:88:in `service'
/home/igneus/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:140:in `service'
/home/igneus/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:96:in `run'
/home/igneus/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/server.rb:296:in `block in start_thread'
```